### PR TITLE
[6주차] 거래 내역 저장 후 입력값 내용 초기화

### DIFF
--- a/fixtures/mockInitState.js
+++ b/fixtures/mockInitState.js
@@ -2,7 +2,7 @@ const mockInitState = {
   budget: 0,
   year: 2021,
   month: 7,
-  selectedType: null,
+  selectedType: '지출',
   transaction: {
     type: '',
     category: '',

--- a/src/slice.js
+++ b/src/slice.js
@@ -1,19 +1,23 @@
 import { createSlice } from '@reduxjs/toolkit';
 
+const initialTransactionFields = {
+  breakdown: 0,
+  source: '',
+  memo: '',
+};
+
 const { actions, reducer } = createSlice({
   name: 'application',
   initialState: {
     budget: 0,
     year: 2021,
     month: 7,
-    selectedType: null,
+    selectedType: '지출',
     transaction: {
       type: '',
       category: '',
       transactionFields: {
-        breakdown: 0,
-        source: '',
-        memo: '',
+        ...initialTransactionFields,
       },
     },
     dailyTransaction: {
@@ -68,6 +72,17 @@ const { actions, reducer } = createSlice({
       return {
         ...state,
         transaction: newTransactionFields,
+      };
+    },
+    clearTransactionFields(state) {
+      return {
+        ...state,
+        transaction: {
+          ...state.transaction,
+          transactionFields: {
+            ...initialTransactionFields,
+          },
+        },
       };
     },
     setTransaction(state, { payload: { transaction } }) {
@@ -131,6 +146,7 @@ export const {
   changeTransactionType,
   changeTransactionCategory,
   changeTransactionFields,
+  clearTransactionFields,
   setTransaction,
   setTransactionHistory,
   setPreviousMonth,

--- a/src/slice.test.js
+++ b/src/slice.test.js
@@ -6,6 +6,7 @@ import reducer, {
   changeTransactionType,
   changeTransactionCategory,
   changeTransactionFields,
+  clearTransactionFields,
   setTransaction,
   setTransactionHistory,
   setPreviousMonth,
@@ -97,6 +98,18 @@ describe('reducer', () => {
 
       expect(state.transaction.transactionFields.memo).toBe('친구들이랑');
     });
+  });
+
+  it('listens clearTransactionFields action', () => {
+    const initialState = {
+      ...mockInitState,
+    };
+
+    const state = reducer(initialState, clearTransactionFields());
+
+    expect(state.transaction.transactionFields.breakdown).toBe(0);
+    expect(state.transaction.transactionFields.source).toBe('');
+    expect(state.transaction.transactionFields.memo).toBe('');
   });
 
   it('listens setTransaction action', () => {

--- a/src/transactionDetail/TransactionInputContainer.jsx
+++ b/src/transactionDetail/TransactionInputContainer.jsx
@@ -5,7 +5,9 @@ import TransactionInput from './TransactionInput';
 import { get } from '../utils/utils';
 
 import {
+  changeTransactionType,
   changeTransactionFields,
+  clearTransactionFields,
   setTransaction,
   setTransactionHistory,
 } from '../slice';
@@ -24,6 +26,8 @@ export default function TransactionInputContainer() {
   const handleSubmit = () => {
     dispatch(setTransaction({ transaction }));
     dispatch(setTransactionHistory({ transaction }));
+    dispatch(clearTransactionFields());
+    dispatch(changeTransactionType());
   };
 
   return (


### PR DESCRIPTION
#66 

✔️ 거래 내역 입력후 `저장`버튼을 클릭하면 입력값  필드(금액, 거래처, 메모) 내용 초기화되어야 한다. 

### ➕ 추가된 기능 
✔️ `내역추가`버튼 클릭하면 초기 상태로 `지출`버튼이 활성화 되어있어야 한다.
✔️  `저장`버튼을 클릭하면 이전에 선택되어 있던 분류(type)으로 활성화 되어 있어야 한다.
