### PR TITLE
[6주차] 저장 버튼 누를 때 제약 조건

### DIFF
--- a/src/transactionDetail/ExpenseCategory.jsx
+++ b/src/transactionDetail/ExpenseCategory.jsx
@@ -42,6 +42,7 @@ export default function ExpenseCategory({ onChange }) {
         data-testid="select"
         name="expense-category"
         onChange={handleChange}
+        defaultValue={expenseCategories[0]}
       >
         {
           expenseCategories.map((category) => (

--- a/src/transactionDetail/IncomeCategory.jsx
+++ b/src/transactionDetail/IncomeCategory.jsx
@@ -38,6 +38,7 @@ export default function IncomeCategory({ onChange }) {
         data-testid="select"
         name="income-category"
         onChange={handleChange}
+        defaultValue={incomeCategories[0]}
       >
         {
           incomeCategories.map((category) => (

--- a/src/transactionDetail/TransactionInputContainer.jsx
+++ b/src/transactionDetail/TransactionInputContainer.jsx
@@ -5,7 +5,6 @@ import TransactionInput from './TransactionInput';
 import { get } from '../utils/utils';
 
 import {
-  changeTransactionType,
   changeTransactionFields,
   clearTransactionFields,
   setTransaction,
@@ -24,10 +23,24 @@ export default function TransactionInputContainer() {
   };
 
   const handleSubmit = () => {
+    if (transactionFields.breakdown === 0) {
+      // eslint-disable-next-line no-alert
+      alert('금액을 입력해주세요.');
+      return;
+    }
+    if (transaction.category === '') {
+      // eslint-disable-next-line no-alert
+      alert('카테고리를 선택해주세요.');
+      return;
+    }
+    if (transactionFields.source === '') {
+      // eslint-disable-next-line no-alert
+      alert('거래처를 입력헤주세요.');
+      return;
+    }
     dispatch(setTransaction({ transaction }));
     dispatch(setTransactionHistory({ transaction }));
     dispatch(clearTransactionFields());
-    dispatch(changeTransactionType());
   };
 
   return (


### PR DESCRIPTION
#67 

### 저장 버튼 누를 때 제약 조건

☑️ `금액이 0`이면 입력값이 없다고 판단하고 '금액을 입력해주세요'  알림창이 뜬다.

☑️ 분류의 경우 초기값을 '지출'로 주었고 `clear 액션`을 만들지 않아 선택값이 없을 경우가 없다.
 - 저장 버튼이 눌러지고 난 다음 이전 선택값이 남아 있게 되는 시나리오의 경우 사용자가 연 달아서 `'지출'에 대한 내용을 입력하고자 한다` 상황을 고려해 적용하였다. 

☑️ 금액이 입력되고, `카테고리` 선택값이 없을 경우  '카테고리를 선택해주세요'  알림창이 뜬다.
- _카테고리 초기화 상태 '미분류'로 설정을 아직 처리하지 못하였다._

☑️ 금액, 분류, 카테고리가 있고, 거래처가 없을 경우 '거래처를 입력해주세요'  알림창이 뜬다.

☑️ 금액, 분류, 카테고리, 거래처가 입력되면 저장 버튼이 활성화 된다. 메모의 경우 선택사항으로 제약 조건에서 제외하였다.
