### PR TITLE
[7주차] 거래내역 추가 되면 총 등록 건수, 총 지출, 총 수입 금액이 보여지도록 기능 개발

### DIFF
--- a/src/slice.js
+++ b/src/slice.js
@@ -62,6 +62,19 @@ const { actions, reducer } = createSlice({
         transaction: selectedCategory,
       };
     },
+    changeBreakdownFields(state, { payload: { value } }) {
+      const newBreakdown = {
+        ...state.transaction,
+        transactionFields: {
+          ...state.transaction.transactionFields,
+          breakdown: parseInt(value, 10),
+        },
+      };
+      return {
+        ...state,
+        transaction: newBreakdown,
+      };
+    },
     changeTransactionFields(state, { payload: { name, value } }) {
       const newTransactionFields = {
         ...state.transaction,
@@ -129,14 +142,14 @@ const { actions, reducer } = createSlice({
         ];
       }
       // 중복 데이터 발생한 것을 삭제해야한다
-      const tragetIndex = newMonthlyTransaction
+      const targetIndex = newMonthlyTransaction
         .findIndex((transactionData) => transactionData.year === year
       && transactionData.month === month
       && transactionData.date === date);
-      // (tragetIndex > -1): 인덱스가 존재한다
+      // (targetIndex > -1): 인덱스가 존재한다
       // 중복 데이터를 삭제해준다
-      if (tragetIndex > -1) {
-        newMonthlyTransaction.splice(tragetIndex, 1);
+      if (targetIndex > -1) {
+        newMonthlyTransaction.splice(targetIndex, 1);
       }
 
       return {
@@ -178,6 +191,7 @@ export const {
   selectType,
   changeTransactionType,
   changeTransactionCategory,
+  changeBreakdownFields,
   changeTransactionFields,
   clearTransactionFields,
   setDailyData,

--- a/src/slice.test.js
+++ b/src/slice.test.js
@@ -8,6 +8,7 @@ import reducer, {
   selectType,
   changeTransactionType,
   changeTransactionCategory,
+  changeBreakdownFields,
   changeTransactionFields,
   clearTransactionFields,
   setDailyData,
@@ -16,7 +17,6 @@ import reducer, {
   setPreviousMonth,
   setNextMonth,
 } from './slice';
-import Transaction from './transaction/Transaction';
 
 describe('reducer', () => {
   context('without state', () => {
@@ -74,7 +74,7 @@ describe('reducer', () => {
     expect(state.transaction.category).toBe('식비');
   });
 
-  describe('change TransactionFields action', () => {
+  describe('change BreakdownFields action', () => {
     const initialState = {
       ...mockInitState,
     };
@@ -82,11 +82,17 @@ describe('reducer', () => {
     it('changes a field of breakdown', () => {
       const state = reducer(
         initialState,
-        changeTransactionFields({ name: 'breakdown', value: 1000 }),
+        changeBreakdownFields({ value: 1000 }),
       );
 
       expect(state.transaction.transactionFields.breakdown).toBe(1000);
     });
+  });
+
+  describe('change TransactionFields action', () => {
+    const initialState = {
+      ...mockInitState,
+    };
 
     it('changes a field of source', () => {
       const state = reducer(

--- a/src/transaction/Transaction.jsx
+++ b/src/transaction/Transaction.jsx
@@ -98,37 +98,94 @@ export default function Transaction({ monthlyTransaction, dailyData }) {
 
   return (
     <>
-      {histories === undefined ? null
-        : histories.transactionHistories.map(({ type, category, transactionFields }) => (
-          <Container
-            key={type}
-          >
-            <DeleteBox>
-              <div>
-                <FontAwesomeIcon icon={faEdit} />
-              </div>
-              <div>
-                <FontAwesomeIcon icon={faTrashAlt} />
-              </div>
-            </DeleteBox>
-            <OptionBox>
-              <Type>{type}</Type>
-              <Category>{category.value}</Category>
-            </OptionBox>
-            <TextBox>
-              <Breakdown>
-                {type === '수입'
-                  ? '+'
-                  : '-'}
-                {' '}
-                {transactionFields.breakdown}
-              </Breakdown>
-              <Text>
-                {`${transactionFields.source} / ${transactionFields.memo}`}
-              </Text>
-            </TextBox>
-          </Container>
-        ))}
+      <div>
+        {
+          histories !== undefined
+            ? (
+              <>
+                <div>
+                  총
+                  {' '}
+                  {histories.transactionHistories.length}
+                  {' '}
+                  건
+                </div>
+                <div>
+                  -
+                  {' '}
+                  {
+                    histories.transactionHistories
+                      .filter((history) => history.type === '지출')
+                      // eslint-disable-next-line max-len
+                      .reduce((sum, b) => sum + b.transactionFields.breakdown, 0)
+                  }
+                  원
+                </div>
+                <div>
+                  +
+                  {' '}
+                  {
+                    histories.transactionHistories
+                      .filter((history) => history.type === '수입')
+                      // eslint-disable-next-line max-len
+                      .reduce((sum, b) => sum + b.transactionFields.breakdown, 0)
+                  }
+                  원
+                </div>
+              </>
+            )
+            : (
+              <>
+                <div>
+                  {' '}
+                  총
+                  {' '}
+                  0
+                  {' '}
+                  건
+                </div>
+              </>
+            )
+        }
+      </div>
+
+      {
+        histories === undefined
+          ? null
+          : histories.transactionHistories.map(({ type, category, transactionFields }) => (
+            <Container
+              key={type}
+            >
+              <DeleteBox>
+                <div>
+                  <FontAwesomeIcon icon={faEdit} />
+                </div>
+                <div>
+                  <FontAwesomeIcon icon={faTrashAlt} />
+                </div>
+              </DeleteBox>
+              <OptionBox>
+                <Type>{type}</Type>
+                <Category>{category.value}</Category>
+              </OptionBox>
+              <TextBox>
+                <Breakdown>
+                  {type === '수입'
+                    ? '+'
+                    : '-'}
+                  {' '}
+                  {transactionFields.breakdown}
+                  {' '}
+                  원
+                </Breakdown>
+                <Text>
+                  {`${transactionFields.source} / ${transactionFields.memo}`}
+                </Text>
+              </TextBox>
+            </Container>
+          ))
+      }
+
     </>
   );
 }

--- a/src/transactionDetail/InputBreakdownField.jsx
+++ b/src/transactionDetail/InputBreakdownField.jsx
@@ -37,14 +37,14 @@ const InputBox = styled.div(mediaquery({
   },
 }));
 
-export default function InputField({
-  label, name, placeholder, value, onChange,
+export default function InputBreakdownField({
+  label, placeholder, value, onChangeBreakdown,
 }) {
-  const id = `input-${name}`;
+  const id = 'input-breakdown';
 
   function handleChange(event) {
     const { target } = event;
-    onChange({ name, value: target.value });
+    onChangeBreakdown({ value: target.value });
   }
 
   return (
@@ -56,9 +56,8 @@ export default function InputField({
       </LabelBox>
       <InputBox>
         <input
-          type="text"
+          type="number"
           id={id}
-          name={name}
           placeholder={placeholder}
           value={value}
           onChange={handleChange}

--- a/src/transactionDetail/InputBreakdownField.test.jsx
+++ b/src/transactionDetail/InputBreakdownField.test.jsx
@@ -1,0 +1,31 @@
+import { render, fireEvent } from '@testing-library/react';
+
+import InputBreakdownField from './InputBreakdownField';
+
+describe('InputBreakdownField', () => {
+  const onChangeBreakdown = jest.fn();
+
+  function renderInputBreakdownField(label = '', value = 0) {
+    return render((
+      <InputBreakdownField
+        label={label}
+        placeholder="0"
+        value={value}
+        onChangeBreakdown={onChangeBreakdown}
+      />
+    ));
+  }
+  it('renders label text', () => {
+    const { getByLabelText } = renderInputBreakdownField();
+
+    expect(getByLabelText('').value).toBe('0');
+  });
+
+  it('listens change events', () => {
+    const { getByPlaceholderText } = renderInputBreakdownField();
+
+    fireEvent.change(getByPlaceholderText('0'), { target: { value: '1000' } });
+
+    expect(onChangeBreakdown).toBeCalledWith({ value: '1000' });
+  });
+});

--- a/src/transactionDetail/TransactionInput.jsx
+++ b/src/transactionDetail/TransactionInput.jsx
@@ -6,6 +6,7 @@ import colors from '../style/colors';
 import mediaquery from '../style/mediaquery';
 
 import InputField from './InputField';
+import InputBreakdownField from './InputBreakdownField';
 import OptionsFieldContainer from './OptionsFieldContainer';
 
 const Container = styled.div(mediaquery({
@@ -58,21 +59,20 @@ const SubmitBox = styled.div(mediaquery({
   letterSpacing: 5,
 }));
 
-export default function TransactionInput({ fields, onChange, onClick }) {
+export default function TransactionInput({
+  fields, onChange, onClick, onChangeBreakdown,
+}) {
   const { breakdown, source, memo } = fields;
 
   return (
     <Container>
       <InputBox>
         <Number>
-          <InputField
+          <InputBreakdownField
             label=""
-            id="breakdown"
-            name="breakdown"
-            type="number"
             placeholder="0"
             value={breakdown}
-            onChange={onChange}
+            onChangeBreakdown={onChangeBreakdown}
           />
         </Number>
         <Child>
@@ -89,7 +89,6 @@ export default function TransactionInput({ fields, onChange, onClick }) {
           label="거래처"
           id="source"
           name="source"
-          type="text"
           placeholder="거래처명을 입력하세요."
           value={source}
           onChange={onChange}
@@ -100,7 +99,6 @@ export default function TransactionInput({ fields, onChange, onClick }) {
           label="메모"
           id="memo"
           name="memo"
-          type="text"
           placeholder="메모를 입력하세요."
           value={memo}
           onChange={onChange}

--- a/src/transactionDetail/TransactionInput.test.jsx
+++ b/src/transactionDetail/TransactionInput.test.jsx
@@ -4,6 +4,7 @@ import TransactionInput from './TransactionInput';
 
 describe('TransactionInput', () => {
   const handleChange = jest.fn();
+  const handleChangeBreakdown = jest.fn();
   const handleSubmit = jest.fn();
 
   beforeEach(() => {
@@ -17,6 +18,8 @@ describe('TransactionInput', () => {
         fields={{ breakdown, source, memo }}
         onChange={handleChange}
         onClick={handleSubmit}
+        onChangeBreakdown={handleChangeBreakdown}
+
       />
     ));
   }

--- a/src/transactionDetail/TransactionInputContainer.jsx
+++ b/src/transactionDetail/TransactionInputContainer.jsx
@@ -5,6 +5,7 @@ import TransactionInput from './TransactionInput';
 import { get } from '../utils/utils';
 
 import {
+  changeBreakdownFields,
   changeTransactionFields,
   clearTransactionFields,
   setTransaction,
@@ -18,7 +19,11 @@ export default function TransactionInputContainer() {
 
   const { transactionFields } = transaction;
 
-  const handleChange = ({ name, value }) => {
+  const handleChangeBreakdown = ({ value }) => {
+    dispatch(changeBreakdownFields({ value }));
+  };
+
+  const handleChangeFields = ({ name, value }) => {
     dispatch(changeTransactionFields({ name, value }));
   };
 
@@ -47,7 +52,8 @@ export default function TransactionInputContainer() {
     <>
       <TransactionInput
         fields={transactionFields}
-        onChange={handleChange}
+        onChange={handleChangeFields}
+        onChangeBreakdown={handleChangeBreakdown}
         onClick={handleSubmit}
       />
     </>

--- a/src/transactionDetail/TransactionInputContainer.test.jsx
+++ b/src/transactionDetail/TransactionInputContainer.test.jsx
@@ -23,6 +23,21 @@ describe('TransactionInputContainer', () => {
     }));
   });
 
+  it('listens changeBreakdownFields events', () => {
+    const { getByPlaceholderText } = render(<TransactionInputContainer />);
+
+    fireEvent.change(getByPlaceholderText('0'), {
+      target: {
+        value: '1000',
+      },
+    });
+
+    expect(dispatch).toBeCalledWith({
+      type: 'application/changeBreakdownFields',
+      payload: { value: '1000' },
+    });
+  });
+
   it('listens change events', () => {
     const { getByLabelText } = render(<TransactionInputContainer />);
 


### PR DESCRIPTION
#78 


### 거래내역 추가 되면 총 등록 건수, 총 지출, 총 수입 금액이 보여지도록 기능 개발 외 추가 내용
- 리덕스 액션 오타 수정
- input change 액션 수정 ( 거래내역 필드(금액, 거래처, 메모) 액션 ->  금액 입력 액션 / 거래처, 메모 입력 액션으로 분리)
  - 이유: 금액 초기값 데이터 숫자형으로 주었는데, 액션을 한꺼번에 일으키니 문자형으로 되어서 새로 수정함